### PR TITLE
source platform-automation image and tasks from Pivnet

### DIFF
--- a/pipelines/delete-environment/pipeline.yml
+++ b/pipelines/delete-environment/pipeline.yml
@@ -52,23 +52,11 @@ resources:
     branch: master
     private_key: ((git_private_key.private_key))
 
-- name: platform-automation-tasks
-  type: s3
+- name: platform-automation
+  type: pivnet
   source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*tasks-(.*).zip
-
-- name: platform-automation-image
-  type: s3
-  source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*image-(.*).tgz
+    api_token: ((pivnet_token))
+    product_slug: platform-automation
 
 - name: vm-state
   type: s3
@@ -87,9 +75,15 @@ jobs:
   - aggregate:
     - get: pipelines-source
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
   - task: interpolate-global
     file: pipelines-source/tasks/interpolate.yml
@@ -119,9 +113,15 @@ jobs:
     - get: pipelines-source
       passed: [delete-installation]
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: vm-state
     - get: terraform-state
       passed: [delete-installation]

--- a/pipelines/install-product/pipeline.yml
+++ b/pipelines/install-product/pipeline.yml
@@ -64,23 +64,11 @@ resources:
     version_path: products.((product_slug)).product-version
     version_pattern: "m.n.p"
 
-- name: platform-automation-tasks
-  type: s3
+- name: platform-automation
+  type: pivnet
   source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*tasks-(.*).zip
-
-- name: platform-automation-image
-  type: s3
-  source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*image-(.*).tgz
+    api_token: ((pivent_token))
+    product_slug: platform-automation
 
 jobs:
 - name: install-tile
@@ -90,9 +78,15 @@ jobs:
     - get: pipelines-source
     - get: product-config
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
     - get: configuration-source
   - task: interpolate-global
@@ -158,9 +152,15 @@ jobs:
     - get: pipelines-source
       #passed: [install-tile]
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
       passed: [install-tile]
     - get: configuration-source
@@ -203,9 +203,15 @@ jobs:
     - get: pipelines-source
       passed: [configure-tile]
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
       passed: [configure-tile]
     - get: configuration-source

--- a/pipelines/install-upgrade-opsman/pipeline.yml
+++ b/pipelines/install-upgrade-opsman/pipeline.yml
@@ -250,7 +250,6 @@ jobs:
       params:
         unpack: true
         globs: ["*image*"]
-      params: {unpack: true}
     - get: terraform-state
       passed: [configure-director]
     - get: configuration-source

--- a/pipelines/install-upgrade-opsman/pipeline.yml
+++ b/pipelines/install-upgrade-opsman/pipeline.yml
@@ -64,23 +64,11 @@ resources:
     version_path: products.opsman.product-version
     version_pattern: "m.n.p"
 
-- name: platform-automation-tasks
-  type: s3
+- name: platform-automation
+  type: pivnet
   source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*tasks-(.*).zip
-
-- name: platform-automation-image
-  type: s3
-  source:
-    region_name: ((s3_region))
-    access_key_id: ((s3_access_key_id))
-    secret_access_key: ((s3_secret_access_key))
-    bucket: ((s3_artifact_bucket))
-    regexp: .*image-(.*).tgz
+    api_token: ((pivnet_token))
+    product_slug: platform-automation
 
 - name: vm-state
   type: s3
@@ -114,9 +102,15 @@ jobs:
     - get: pipelines-source
     - get: product-config-opsman
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
       passed: [terraform]
       trigger: true
@@ -192,9 +186,15 @@ jobs:
   - aggregate:
     - get: pipelines-source
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
     - get: terraform-state
       trigger: true
       passed: [create-opsman]
@@ -241,8 +241,15 @@ jobs:
   - aggregate:
     - get: pipelines-source
     - get: platform-automation-tasks
-      params: {unpack: true}
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*tasks*"]
     - get: platform-automation-image
+      resource: platform-automation
+      params:
+        unpack: true
+        globs: ["*image*"]
       params: {unpack: true}
     - get: terraform-state
       passed: [configure-director]


### PR DESCRIPTION
To make it a more streamlined experience for POCs, switch to sourcing the platform automation image and tasks directly from Pivnet.